### PR TITLE
Start extracting functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 script:
 - lein cljfmt check
 - lein test
-- lein uberjar
 after_success:
 - CLOVERAGE_VERSION=1.0.7-SNAPSHOT lein cloverage --codecov
 - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,21 @@
 (defproject cloudpassage-lib "0.1.0-SNAPSHOT"
-  :description "Clojure interface for the CloudPassage API"
-  :url "https://github.com/RackSec/cloudpassage-lib"
+  :description "A library for interacting with cloudpassage apis."
+  :url "http://github.com/RackSec/cloudpassage-lib"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]]
-  :plugins [[lein-cljfmt "0.3.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [com.taoensso/timbre "4.2.0"]
+                 [manifold "0.1.2"]
+                 [aleph "0.4.1-beta2"]
+                 [clj-time "0.11.0"]
+                 [base64-clj "0.1.1"]
+                 [cheshire "5.5.0"]
+                 [com.cemerick/url "0.1.1"]]
+  :plugins [[lein-auto "0.1.2"]
+            [lein-cljfmt "0.3.0"]
             [lein-pprint "1.1.1"]
             [lein-cloverage "1.0.7-SNAPSHOT"]]
   :min-lein-version "2.0.0"
-  :main ^:skip-aot cloudpassage-lib.core
-  :uberjar-name "cloudpassage-lib.jar"
-  :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[pjstadig/humane-test-output "0.7.1"]]
+  :profiles {:dev {:dependencies [[pjstadig/humane-test-output "0.7.1"]]
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]}})

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -1,1 +1,73 @@
-(ns cloudpassage-lib.core)
+(ns cloudpassage-lib.core
+  (:require
+   [clojure.string :as str]
+   [aleph.http :as http]
+   [manifold.deferred :as md]
+   [manifold.time :as mt]
+   [byte-streams :as bs]
+   [taoensso.timbre :as timbre :refer [info error]]
+   [base64-clj.core :as base64]
+   [clj-time.core :as time]
+   [clj-time.format :as f]
+   [cheshire.core :as json]))
+
+;; the url from which new auth-tokens can be obtained.
+(def auth-uri "https://api.cloudpassage.com/oauth/access_token?grant_type=client_credentials")
+(def events-uri "https://api.cloudpassage.com/v1/events?")
+
+(defn ^:private ->basic-auth-header
+  [client-id client-key]
+  (let [together (str client-id ":" client-key)
+        encoded (base64/encode together)]
+    {"Authorization" (str/join " " ["Basic" encoded])}))
+
+(defn ^:private ->bearer-auth-header
+  [auth-token]
+  {"Authorization" (str/join " " ["Bearer" auth-token])})
+
+(def cp-date-formatter
+  (f/formatter "yyyy-MM-dd'T'HH:mm:ss'Z'"))
+
+(defn ->cp-date
+  [date]
+  (f/unparse cp-date-formatter date))
+
+(defn get-auth-token!
+  "Using the secret key and an ID, fetch a new auth token.
+
+  client-key - a string representing the key provided by cloudpassage.
+  client-id - a string representing an customer.
+
+  returns a new auth token hashmap"
+  [client-id client-key]
+  (info "fetching new auth token for" client-id)
+  (let [sent-at (time/now)
+        auth-header (->basic-auth-header client-id client-key)
+        token @(md/chain
+                (http/post auth-uri {:headers auth-header})
+                :body
+                bs/to-string
+                (fn [response]
+                  (json/parse-string response true)))]
+    token))
+
+(defn get-single-events-page!
+  "get a page at `uri` using the provided `auth-token`.
+
+  returns a `manifold.deferred/deferred` that when realized contains a clojure
+  map representing the body of an http response."
+  [auth-token uri]
+  (info "fetching" uri)
+  (let [auth-header (->bearer-auth-header auth-token)]
+    (->
+     (md/chain
+      (http/get uri {:headers auth-header})
+      :body
+      bs/to-string
+      (fn [body-bytes]
+        (json/parse-string body-bytes true)))
+     (md/catch
+      Exception
+      (fn [exc]
+        (error "error fetching events page:" (.getMessage exc))
+        ::fetch-error)))))

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -1,3 +1,47 @@
 (ns cloudpassage-lib.core-test
   (:require [clojure.test :refer :all]
-            [cloudpassage-lib.core :refer :all]))
+            [manifold.deferred :as md]
+            [clj-time.core :as ct]
+            [cheshire.core :as json]
+            [cloudpassage-lib.core :as core]))
+
+(deftest get-auth-token!-tests
+  (testing "returns an authentication token"
+    (let [sent-at (ct/now)
+          expires-at (ct/plus sent-at (ct/seconds 900))
+          response {:access_token "ffad76cc550110fc4c84a18397b6e104"
+                    :expires_in 900
+                    :token_type "bearer"}
+          fake-post (fn [_addr _opts]
+                      (let [foo (md/deferred)]
+                        (md/success!
+                         foo
+                         {:body (json/generate-string response)})
+                        foo))]
+      (with-redefs [aleph.http/post fake-post
+                    clj-time.core/now (fn [] sent-at)]
+        (is (= response (core/get-auth-token! "secret-key" "id")))))))
+
+(deftest iso-date-tests
+  (testing "it actually formats dates"
+    (let [a-date (ct/date-time 1986 10 14 4 3 27 456)
+          formatted (core/->cp-date a-date)]
+      (is (= formatted "1986-10-14T04:03:27Z")))))
+
+(deftest get-single-events-page!-tests
+  (testing "returns ::fetch-error on exception"
+    (let [fake-get (fn [_addr _headers]
+                     (let [d (md/deferred)]
+                       (md/error! d (Exception. "kaboom"))
+                       d))]
+      (with-redefs [aleph.http/get fake-get]
+        (is (= :cloudpassage-lib.core/fetch-error
+               @(core/get-single-events-page! "" ""))))))
+  (testing "returns deserialized json body"
+    (let [fake-get (fn [_addr _headers]
+                     (let [d (md/deferred)]
+                       (md/success! d {:body (json/generate-string {:events []})})
+                       d))]
+      (with-redefs [aleph.http/get fake-get]
+        (is (= {:events []}
+               @(core/get-single-events-page! "" "")))))))


### PR DESCRIPTION
This is the first pass at pulling out logic.

Includes
- get-auth-token! - this is meant to fetch a token from their api
  using the secret key and id provided by cp. How this is persisted
  is up to the consumer.
- get-single-events-page! - used to issue requests against the cp
  api.
- ->cp-date - function for formatting dates in way that their api
  expects.