### PR TITLE
Convert all report responses to kebab-case

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
                  [fernet "0.1.0"]
                  [environ "1.0.1"]
                  [cheshire "5.5.0"]
+                 [camel-snake-kebab "0.3.2"]
                  [com.cemerick/url "0.1.1"]]
   :plugins [[lein-auto "0.1.2"]
             [lein-cljfmt "0.3.0"]

--- a/src/cloudpassage_lib/scans.clj
+++ b/src/cloudpassage_lib/scans.clj
@@ -12,6 +12,8 @@
    [taoensso.timbre :as timbre :refer [info spy]]
    [clj-time.core :as t :refer [hours ago]]
    [clj-time.format :as tf]
+   [camel-snake-kebab.core :as cskc]
+   [camel-snake-kebab.extras :as cske]
    [clojure.java.io :as io]))
 
 (def ^:private base-scans-url
@@ -114,6 +116,7 @@
     (->> (scans! client-id client-secret opts)
          (ms/filter (fn [{:keys [module]}] (= module module-name)))
          (scans-with-details! client-id client-secret)
+         (ms/map #(cske/transform-keys cskc/->kebab-case-keyword %))
          ms/stream->seq)))
 
 (defn fim-report!

--- a/test/cloudpassage_lib/scans_test.clj
+++ b/test/cloudpassage_lib/scans_test.clj
@@ -159,4 +159,3 @@
 
 (deftest sca-report!-tests
   (test-report scans/sca-report! "sca"))
-


### PR DESCRIPTION
This will be a breaking change for api consumers. 

I've chosen to perform this step inside of `report-for-module` because it needs to occur for *all* data returned by the api; `report-for-module` is responsible for producing all of this data.
