### PR TITLE
Change API calls used to get scan data

### DIFF
--- a/test/cloudpassage_lib/scans_test.clj
+++ b/test/cloudpassage_lib/scans_test.clj
@@ -44,6 +44,10 @@
   (is (= "https://abc.com/v1/scans/abcdef/findings/xyzzy"
          (#'scans/finding-detail-url "https://abc.com/" "abcdef" "xyzzy"))))
 
+(deftest scan-server-url-tests
+  (is (= "https://api.cloudpassage.com/v1/servers/server-id/svm"
+         (#'scans/scan-server-url "server-id" "svm"))))
+
 (defn ^:private index->module
   "Given an index of a (fake, test-only) scan, return a module for that scan."
   [i]
@@ -163,28 +167,112 @@
            ms/stream->seq
            doall))))
 
+(defn ^:private mock-get-page
+  "Generates a fake page function. Give it the expected base path and a
+   function to call with the current page number."
+  [cb]
+  (fn [client-id client-secret url]
+    (is (= client-id "lvh"))
+    (is (= client-secret "hunter2"))
+    (let [parsed-url (u/url url)
+          path (:path parsed-url)
+          query (:query parsed-url)
+          page-num (-> query
+                       (get "page" "0")
+                       Integer/parseInt)]
+      (cb {:page-num page-num :path path}))))
+
+(deftest list-servers!-tests
+  (testing "Returns all servers if paginated call is OK."
+    (println #'scans/base-servers-url)
+    (with-redefs [scans/get-page!
+                  (mock-get-page
+                   (fn [{:keys [page-num path]}]
+                     (is (= "/v1/servers" path))
+                     (case page-num
+                       0 {:servers [{:id "server-id-1"} {:id "server-id-2"}]
+                          :pagination {:next (str @#'scans/base-servers-url "?page=1")}}
+                       1 {:servers [{:id "server-id-3"}]})))]
+      (let [server-stream (scans/list-servers! "lvh" "hunter2")
+            id-list (map :id (ms/stream->seq server-stream))]
+        (is (= ["server-id-1" "server-id-2" "server-id-3"] id-list))
+        (is (ms/closed? server-stream))))
+    (testing "If page 2 is bad, a partial list is returned."
+      (with-redefs [scans/get-page!
+                    (mock-get-page
+                     (fn [{:keys [page-num path]}]
+                       (is (= "/v1/servers" path))
+                       (case page-num
+                         0 {:servers [{:id "server-id-1"} {:id "server-id-2"}]
+                            :pagination {:next (str @#'scans/base-servers-url "?page=1")}}
+                         1 :cloudpassage-lib.core/fetch-error)))]
+        (let [server-stream (scans/list-servers! "lvh" "hunter2")
+              id-list (map :id (ms/stream->seq server-stream))]
+          (is (= ["server-id-1" "server-id-2"] id-list))
+          (is (ms/closed? server-stream)))))))
+
+(deftest scan-server-tests
+  (with-redefs
+   [scans/get-page! (mock-get-page
+                     (fn [{:keys [path]}]
+                       (is (= "/v1/servers/server-id-here/svm" path))
+                       "GOOD"))]
+    (is (= "GOOD" (scans/scan-server "lvh" "hunter2" "server-id-here" "svm")))))
+
+(deftest scan-each-server!-tests
+  (testing "Scan can handle an empty stream."
+    (let [input (ms/stream)]
+      (ms/close! input)
+      (let [scan-stream (scans/scan-each-server! "lvh" "hunter2" "svm"
+                                                 input)
+            scan-result (clojure.string/join "" (ms/stream->seq scan-stream))]
+        (is (= "" scan-result)))))
+  (testing "When the server scan page is broken, we get back nadda."
+    (with-redefs [scans/get-page! (mock-get-page
+                                   (fn [{:keys [path]}]
+                                     (is (= "/v1/servers/server-id-here/svm" path))
+                                     :cloudpassage-lib.core/fetch-error))]
+      (let [input (ms/stream)]
+        (ms/put! input {:id "server-id-here"})
+        (ms/close! input)
+        (let [scan-stream (scans/scan-each-server! "lvh" "hunter2" "svm"
+                                                   input)
+              scan-result (clojure.string/join "" (ms/stream->seq scan-stream))]
+          (is (= "" scan-result))))))
+  (testing "Server scan can get back several pages of data."
+    (with-redefs [scans/get-page! (mock-get-page
+                                   (fn [{:keys [path]}]
+        ;; The real data returning from a valid scan-server call would be a
+        ;; map containing a bunch of scan data. But for testing purposes all
+        ;; that matters is that scan-each-server! puts whatever comes back
+        ;; into the its output stream.
+                                     (case path
+                                       "/v1/servers/server-1/svm" "ONE"
+                                       "/v1/servers/server-2/svm" "TWO"
+                                       "/v1/servers/server-3/svm" "THREE!")))]
+      (let [input (ms/stream 2)]
+        (ms/put-all! input [{:id "server-1"} {:id "server-2"} {:id "server-3"}])
+        (ms/close! input)
+        (let [scan-stream
+              (scans/scan-each-server! "lvh" "hunter2" "svm" input)
+              scan-result
+              (clojure.string/join "..." (ms/stream->seq scan-stream))]
+          (is (= "ONE...TWO...THREE!" scan-result)))))))
+
 (defn ^:private test-report
   [report-fn! expected-module]
-  (with-redefs [scans/get-page! fake-get-page!]
-    (let [report (report-fn! "lvh" "hunter2")]
-      (is (= (for [scan-id (range (* fake-pages scans-per-page))
-                   :let [module (index->module scan-id)]
-                   :when (= module expected-module)]
-               {:scan-id scan-id
-                :module module
-                :url details-query-url
-                :scan {}})
-             report))))
-  (with-redefs [scans/get-page! fake-get-page-with-snakes]
-    (let [report (report-fn! "lvh" "hunter2")]
-      (is (= (for [scan-id (range (* fake-pages scans-per-page))
-                   :let [module (index->module scan-id)]
-                   :when (= module expected-module)]
-               {:scan-id scan-id
-                :module module
-                :url details-query-url
-                :scan {}})
-             report)))))
+  (with-redefs
+   [scans/get-page!
+    (mock-get-page
+     (fn [{:keys [path]}]
+       (cond
+         (= path "/v1/servers") {:servers [{:id "server-id-1"} {:id "server-id-2"}]}
+         (= path (str "/v1/servers/server-id-1/" expected-module)) {:id "1" :scan {}}
+         (= path (str "/v1/servers/server-id-2/" expected-module)) {:id "2" :scan {}})))]
+    (let [report (report-fn! "lvh" "hunter2")
+          result (clojure.string/join "..." report)]
+      (is (= (str {:id "1", :scan {}} "..." {:id "2", :scan {}})
+             result)))))
 
 (deftest fim-report!-tests
   (test-report scans/fim-report! "fim"))


### PR DESCRIPTION
Previously we've been using the scans API to fetch data by time to
generate our report. This PR changes it to fetch the most recent
scans for each server (aka host) which keeps us from having to
use large time periods in our query to make sure we get some data
for each server while also having to throw our duplicate info for
any server which may appear.