### PR TITLE
Retry logic for HTTP errors

### DIFF
--- a/src/cloudpassage_lib/scans.clj
+++ b/src/cloudpassage_lib/scans.clj
@@ -7,6 +7,7 @@
    [aleph.http :as http]
    [manifold.deferred :as md]
    [manifold.stream :as ms]
+   [manifold.time :as mt]
    [environ.core :refer [env]]
    [cloudpassage-lib.core :as cpc]
    [taoensso.timbre :as timbre :refer [error info spy]]
@@ -56,7 +57,9 @@
            (throw (Exception. "Error fetching scans.")))
        :else
        (do (error "Couldn't fetch page. Retrying.")
-           (get-page-retry! token url (dec num-retries)))))))
+           (mt/in
+            3000
+            #(get-page-retry! token url (dec num-retries))))))))
 
 (defn ^:private get-page!
   "Gets a page, and handles auth for you."

--- a/src/cloudpassage_lib/scans.clj
+++ b/src/cloudpassage_lib/scans.clj
@@ -46,7 +46,7 @@
 
 (defn ^:private get-page-retry!
   "Gets a page, and handles retries on error."
-  [token url num-retries]
+  [token url num-retries timeout]
   (md/chain
    (cpc/get-single-events-page! token url)
    (fn [response]
@@ -58,14 +58,14 @@
        :else
        (do (error "Couldn't fetch page. Retrying.")
            (mt/in
-            3000
-            #(get-page-retry! token url (dec num-retries))))))))
+            timeout
+            #(get-page-retry! token url (dec num-retries) timeout)))))))
 
 (defn ^:private get-page!
   "Gets a page, and handles auth for you."
   [client-id client-secret url]
   (let [token (cpc/fetch-token! client-id client-secret (:fernet-key env))]
-    (get-page-retry! token url 3)))
+    (get-page-retry! token url 3 3000)))
 
 (defn ^:private stream-paginated-resources!
   "Returns a stream of resources coming from a paginated list."

--- a/src/cloudpassage_lib/scans.clj
+++ b/src/cloudpassage_lib/scans.clj
@@ -43,6 +43,17 @@
   [server-id module]
   (str (u/url base-servers-url server-id module)))
 
+(defn ^:private get-page-retry!
+  "Gets a page, and handles auth for you."
+  [token url num-tries]
+  (let [response (cpc/get-single-events-page! token url)]
+    (cond
+      (cpc/page-response-ok? response) response
+      (zero? num-tries) 'fail
+      :else
+      (do (error "Couldn't fetch page. Retrying.")
+          (recur token url (dec num-tries))))))
+
 (defn ^:private get-page!
   "Gets a page, and handles auth for you."
   [client-id client-secret url]

--- a/test/cloudpassage_lib/scans_test.clj
+++ b/test/cloudpassage_lib/scans_test.clj
@@ -65,7 +65,7 @@
               num-retries 3
               log (use-atom-log-appender!)]
           (mt/with-clock c
-            (let [response (#'scans/get-page-retry! '_ '_ num-retries)]
+            (let [response (#'scans/get-page-retry! '_ '_ num-retries timeout)]
               (mt/advance c (* timeout num-retries))
               (is (thrown-with-msg?
                    Exception
@@ -83,7 +83,7 @@
       (with-redefs [cpc/get-single-events-page! fake-get]
         (let [log (use-atom-log-appender!)
               ;; Returns instantly since no retries are necessary
-              response @(#'scans/get-page-retry! '_ '_ 3)]
+              response @(#'scans/get-page-retry! '_ '_ 3 3000)]
           (is (= scan response))
           (is (= 0 (count @log))))))))
 


### PR DESCRIPTION
Fixes #41.

WIP. Next steps:

- [x] Figure out what to do instead of passing the symbol "fail", probably throw an exception
- [x] Update `get-page!` to wrap `get-page-retry!` 
- [x] Remove the error handling inside various functions inside scans