### PR TITLE
Auth error handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                  [environ "1.0.1"]
                  [cheshire "5.5.0"]
                  [camel-snake-kebab "0.3.2"]
+                 [org.clojure/math.numeric-tower "0.0.4"]
                  [com.cemerick/url "0.1.1"]]
   :plugins [[lein-auto "0.1.2"]
             [lein-cljfmt "0.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.taoensso/timbre "4.2.0"]
-                 [manifold "0.1.2"]
+                 [manifold "0.1.4"]
                  [aleph "0.4.1-beta2"]
                  [clj-time "0.11.0"]
                  [base64-clj "0.1.1"]

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -1,7 +1,6 @@
 (ns cloudpassage-lib.core
   (:require
    [clojure.string :as str]
-   [clojure.math.numeric-tower :as math]
    [aleph.http :as http]
    [environ.core :refer [env]]
    [manifold.deferred :as md]
@@ -13,6 +12,7 @@
    [clj-time.core :as time]
    [clj-time.format :as f]
    [cloudpassage-lib.fernet :as fernet]
+   [cloudpassage-lib.retry :as retry]
    [cheshire.core :as json]))
 
 ;; the url from which new auth-tokens can be obtained.
@@ -45,58 +45,6 @@
   [date]
   (f/unparse cp-date-formatter date))
 
-(defn exponentially
-  "Returns a function that when evaluated will produce the initial wait
-  raised to the number of failures.
-
-  This is intended to be used in conjunction with other 2-arg combinators,
-  e.g., `up-to`."
-  [wait]
-  (fn [failures]
-    (math/expt wait (count failures))))
-
-(defn up-to
-  "Returns a function that when evaluated will either
-
-  1) return a number to use to wait until retrying a function again. Or,
-  2) throw an exception because the maximum number of retries, `stop` has
-  been reached.
-
-  This is intended to be used in conjunction with other 2-arg combinators,
-  e.g., `up-to`."
-  [stop retry?]
-  (fn [failures]
-    (if (< (count failures) stop)
-      (retry? failures)
-      (throw (last failures)))))
-
-(defn retry
-  "Takes a function that returns a `manifold.deferred/deferred`. Retries that
-  function until it succeeds or the number of failures equal the stop value.
-
-  `retry` expects to encounter exceptions when retrying `f`. As such,
-  it will catch all exceptions that `f` might throw and continue retrying.
-
-  f - a function that should be retried; must return a
-      `manifold.deferred/deferred'
-  p - an int representing the initial number of seconds to wait before retrying.
-      This will grow exponentially for each attempt.
-  stop - an int representing the number of tries that the api should make before
-         giving up and returning `:cloudpassage-lib.core/retry-failure`.
-
-  Returns a deferred wrapping the results of `f`."
-  [f p stop]
-  (let [try-after (->> (exponentially p)
-                       (up-to stop))]
-    (md/loop [failures []]
-      (md/catch
-       (f)
-       Exception
-        (fn [exc]
-          (let [all-failures (conj failures exc)
-                wait (try-after all-failures)]
-            (mt/in (mt/seconds wait) #(md/recur all-failures))))))))
-
 (defn get-auth-token!
   "Using the secret key and an ID, fetch a new auth token.
 
@@ -112,7 +60,7 @@
         starting-retry 4
         stop-after 3]
     (md/chain
-     (retry
+     (retry/retry-exp-backoff
       #(http/post auth-uri {:headers auth-header})
       starting-retry
       stop-after)

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -46,8 +46,8 @@
   (f/unparse cp-date-formatter date))
 
 (defn retry
-  "Takes a function that returns a deferred. Retries that function
-  until it succeeds or the number of failures equal the stop value
+  "Takes a function that returns a `manifold.deferred/deferred`. Retries that
+  function until it succeeds or the number of failures equal the stop value.
 
   `retry` expects to encounter exceptions when retrying `f`. As such,
   it will catch all exceptions that `f` might throw and continue retrying.
@@ -57,7 +57,7 @@
   f - a function that should be retried; must return a
       `manifold.deferred/deferred'
   stop - an int representing the number of tries that the api should make before
-         giving up and throwing an exception/dying.
+         giving up and returning `:cloudpassage-lib.core/retry-failure`.
 
   Returns a deferred wrapping the results of `f`."
   [p f stop]

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -106,10 +106,7 @@
       #(http/post auth-uri {:headers auth-header})
       starting-retry
       stop-after)
-     (fn [val]
-       (if (= ::retry-failure val)
-         ::auth-failure
-         (json/parse-stream (bs/to-reader (:body val)) true))))))
+     #(json/parse-stream (bs/to-reader (:body %)) true))))
 
 (defn get-single-events-page!
   "get a page at `uri` using the provided `auth-token`.

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -97,7 +97,7 @@
   (let [sent-at (time/now)
         auth-header (->basic-auth-header client-id client-key)
         starting-retry 5
-        stop-after 5]
+        stop-after 3]
     (md/chain
      (retry
       #(http/post auth-uri {:headers auth-header})

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -44,6 +44,21 @@
   [date]
   (f/unparse cp-date-formatter date))
 
+(defn retry!
+  "Takes a function that returns a deferred. Retries that function
+  until it succeeds or the number of failures equal the stop value
+
+  `retry` expects to encounter exceptions when retrying `f`. As such,
+  it will catch all exceptions that `f` might throw and continue retrying.
+
+  f - a function that should be retried; must return a `manifold.deferred/deferred'
+  stop - an int representing the number of tries that the api should make before
+         giving up and throwing an exception/dying.
+
+  Returns a deferred wrapping the results of `f`."
+  [f stop]
+  nil)
+
 (defn get-auth-token!
   "Using the secret key and an ID, fetch a new auth token.
 

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -61,20 +61,16 @@
 
   Returns a deferred wrapping the results of `f`."
   [f p stop]
-  (let [try-again (fn [tries]
-                    (let [wait (mt/seconds (math/expt p tries))]
-                      (mt/in wait #(md/recur (inc tries)))))]
-    (md/loop [tries 1]
-      (md/catch
-       (f)
-       Exception
-        (fn [exc]
-          (error "Failure retrying:" (.getMessage exc))
-          (if (= tries stop)
-            (do
-              (error "Failed retrying" tries "times; stopping")
-              (throw (Exception. "Failed retrying; stopping.")))
-            (try-again tries)))))))
+  (md/loop [tries 1]
+    (md/catch
+     (f)
+     Exception
+      (fn [exc]
+        (error "Failure retrying:" exc)
+        (if (= tries stop)
+          (throw exc))
+        (let [wait (mt/seconds (math/expt p tries))]
+          (mt/in wait #(md/recur (inc tries))))))))
 
 (defn get-auth-token!
   "Using the secret key and an ID, fetch a new auth token.

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -150,7 +150,6 @@
       ;; a token is in redis
       (fernet/decrypt fernet-key token)
       ;; no token is present, fetch a new one
-      ;; the operation to fetch the token should be asynchronous
       (let [new-token @(get-auth-token! client-id client-secret)
             ;; this will cause the token to expire 100 seconds earlier than expiration
             ;; it is a simple fudge factor.

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -46,11 +46,24 @@
   (f/unparse cp-date-formatter date))
 
 (defn exponentially
+  "Returns a function that when evaluated will produce the initial wait
+  raised to the number of failures.
+
+  This is intended to be used in conjunction with other 2-arg combinators,
+  e.g., `up-to`."
   [wait]
   (fn [failures]
     (math/expt wait (count failures))))
 
 (defn up-to
+  "Returns a function that when evaluated will either
+
+  1) return a number to use to wait until retrying a function again. Or,
+  2) throw an exception because the maximum number of retries, `stop` has
+  been reached.
+
+  This is intended to be used in conjunction with other 2-arg combinators,
+  e.g., `up-to`."
   [stop retry?]
   (fn [failures]
     (if (< (count failures) stop)

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -108,7 +108,6 @@
          ::auth-failure
          (json/parse-stream (bs/to-reader (:body val)) true))))))
 
-
 (defn get-single-events-page!
   "get a page at `uri` using the provided `auth-token`.
 

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -94,7 +94,8 @@
   client-key - a string representing the key provided by cloudpassage.
   client-id - a string representing an customer.
 
-  returns a new auth token hashmap"
+  returns a `manifold.deferred/deferred' wrapping an authentication
+  token hashmap"
   [client-id client-key]
   (info "fetching new auth token for" client-id)
   (let [sent-at (time/now)

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -65,17 +65,16 @@
                     (let [wait (mt/seconds (math/expt p tries))]
                       (mt/in wait #(md/recur (inc tries)))))]
     (md/loop [tries 1]
-      (md/chain
-       (md/catch
-        (f)
-        Exception
-         (fn [exc]
-           (error "Failure retrying:" (.getMessage exc))
-           (if (= tries stop)
-             (do
-               (error "Failed retrying" tries "times; stopping")
-               (throw (Exception. "Failed retrying; stopping.")))
-             (try-again tries))))))))
+      (md/catch
+       (f)
+       Exception
+        (fn [exc]
+          (error "Failure retrying:" (.getMessage exc))
+          (if (= tries stop)
+            (do
+              (error "Failed retrying" tries "times; stopping")
+              (throw (Exception. "Failed retrying; stopping.")))
+            (try-again tries)))))))
 
 (defn get-auth-token!
   "Using the secret key and an ID, fetch a new auth token.

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -95,7 +95,7 @@
   client-id - a string representing an customer.
 
   returns a `manifold.deferred/deferred' wrapping an authentication
-  token hashmap"
+  token hash map"
   [client-id client-key]
   (info "fetching new auth token for" client-id)
   (let [sent-at (time/now)

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -52,6 +52,8 @@
   `retry` expects to encounter exceptions when retrying `f`. As such,
   it will catch all exceptions that `f` might throw and continue retrying.
 
+  p - an int representing the initial number of seconds to wait before retrying.
+      This will grow exponentially for each attempt.
   f - a function that should be retried; must return a
       `manifold.deferred/deferred'
   stop - an int representing the number of tries that the api should make before

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -45,6 +45,18 @@
   [date]
   (f/unparse cp-date-formatter date))
 
+(defn exponentially
+  [wait]
+  (fn [failures]
+    (math/expt wait (count failures))))
+
+(defn up-to
+  [stop retry?]
+  (fn [failures]
+    (if (< (count failures) stop)
+      (retry? failures)
+      (throw (last failures)))))
+
 (defn retry
   "Takes a function that returns a `manifold.deferred/deferred`. Retries that
   function until it succeeds or the number of failures equal the stop value.

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -68,7 +68,10 @@
                     Exception
                     (fn [exc]
                       (error "Failure retrying:" (.getMessage exc))
-                      exc))))]
+                      exc))))
+        recur-in (fn [tries]
+                   (let [wait (mt/seconds (math/expt p tries))]
+                     (mt/in wait #(md/recur (inc tries)))))]
     (md/loop [tries 1]
       (md/chain
        (invoker)
@@ -86,8 +89,7 @@
 
              ;; keep retrying
              (and (< tries stop) errval?)
-             (let [wait (mt/seconds (math/expt p tries))]
-               (mt/in wait #(md/recur (inc tries)))))))))))
+             (recur-in tries))))))))
 
 (defn get-auth-token!
   "Using the secret key and an ID, fetch a new auth token.

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -45,7 +45,7 @@
   [date]
   (f/unparse cp-date-formatter date))
 
-(defn retry!
+(defn retry
   "Takes a function that returns a deferred. Retries that function
   until it succeeds or the number of failures equal the stop value
 
@@ -80,7 +80,7 @@
            (do
              (error "Failed retrying" @tries "times; stopping")
              ::retry-failure)
-           ;; try again after the waiting period
+           ;; try again, after the waiting period
            (and (< @tries stop) (= ::local-retry-error val))
            (let [wait (mt/seconds (math/expt p @tries))]
              (mt/in wait md/recur))))))))

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -52,15 +52,15 @@
   `retry` expects to encounter exceptions when retrying `f`. As such,
   it will catch all exceptions that `f` might throw and continue retrying.
 
-  p - an int representing the initial number of seconds to wait before retrying.
-      This will grow exponentially for each attempt.
   f - a function that should be retried; must return a
       `manifold.deferred/deferred'
+  p - an int representing the initial number of seconds to wait before retrying.
+      This will grow exponentially for each attempt.
   stop - an int representing the number of tries that the api should make before
          giving up and returning `:cloudpassage-lib.core/retry-failure`.
 
   Returns a deferred wrapping the results of `f`."
-  [p f stop]
+  [f p stop]
   (let [invoker (fn []
                   (->
                    (f)

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -96,7 +96,7 @@
   (info "fetching new auth token for" client-id)
   (let [sent-at (time/now)
         auth-header (->basic-auth-header client-id client-key)
-        starting-retry 5
+        starting-retry 4
         stop-after 3]
     (md/chain
      (retry

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -73,16 +73,8 @@
 
   Returns a deferred wrapping the results of `f`."
   [f p stop]
-  (let [;; try-after is essentially the back-off strategy
-        ;; it does not handle retrying itself, but is responsible
-        ;; for determining whether to continue retrying and
-        ;; if so, how long to wait until the next retry.
-        try-after (fn [exceptions]
-                    (let [ct (count exceptions)
-                          next-wait (math/expt p ct)]
-                      (if (< ct stop)
-                        next-wait
-                        (throw (last exceptions)))))]
+  (let [try-after (->> (exponentially p)
+                       (up-to stop))]
     (md/loop [failures []]
       (md/catch
        (f)

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -75,11 +75,14 @@
        (fn [val]
          (cond
            (not= ::local-retry-error val) val
+
            ;; stop trying
            (and (= tries stop) (= ::local-retry-error val))
-           (do
+           (let [d (md/deferred)]
              (error "Failed retrying" tries "times; stopping")
-             ::retry-failure)
+             (md/error! d (Exception. "Failed retrying"))
+             d)
+
            ;; try again, after the waiting period
            (and (< tries stop) (= ::local-retry-error val))
            (let [wait (mt/seconds (math/expt p tries))]

--- a/src/cloudpassage_lib/retry.clj
+++ b/src/cloudpassage_lib/retry.clj
@@ -18,7 +18,7 @@
   "Returns a function that when evaluated will either
 
   1) return a number to use to wait until retrying a function again. Or,
-  2) throw an exception because the maximum number of retries, `stop` has
+  2) throw an exception because the maximum number of retries, `stop`, has
   been reached.
 
   This is intended to be used in conjunction with other 1-arg combinators,

--- a/src/cloudpassage_lib/retry.clj
+++ b/src/cloudpassage_lib/retry.clj
@@ -1,0 +1,57 @@
+(ns cloudpassage-lib.retry
+  (:require
+   [clojure.math.numeric-tower :as math]
+   [manifold.deferred :as md]
+   [manifold.time :as mt]))
+
+(defn exponentially
+  "Returns a function that when evaluated will produce the initial wait
+  raised to the number of failures.
+
+  This is intended to be used in conjunction with other 1-arg combinators,
+  that take a vector of failures."
+  [wait]
+  (fn [failures]
+    (math/expt wait (count failures))))
+
+(defn up-to
+  "Returns a function that when evaluated will either
+
+  1) return a number to use to wait until retrying a function again. Or,
+  2) throw an exception because the maximum number of retries, `stop` has
+  been reached.
+
+  This is intended to be used in conjunction with other 1-arg combinators,
+  that take a vector of failures."
+  [stop retry?]
+  (fn [failures]
+    (if (< (count failures) stop)
+      (retry? failures)
+      (throw (last failures)))))
+
+(defn retry-exp-backoff
+  "Takes a function that returns a `manifold.deferred/deferred`. Retries that
+  function until it succeeds or the number of failures equal the stop value.
+
+  Expects to encounter exceptions when retrying `f`. As such,
+  it will catch all exceptions that `f` might throw and continue retrying.
+
+  f - a function that should be retried; must return a
+      `manifold.deferred/deferred'
+  p - an int representing the initial number of seconds to wait before retrying.
+      This will grow exponentially for each attempt.
+  stop - an int representing the number of tries that the api should make before
+         giving up and returning the last exception encountered.
+
+  Returns a deferred wrapping the results of `f`."
+  [f p stop]
+  (let [try-after (->> (exponentially p)
+                       (up-to stop))]
+    (md/loop [failures []]
+      (md/catch
+       (f)
+       Exception
+        (fn [exc]
+          (let [all-failures (conj failures exc)
+                wait (try-after all-failures)]
+            (mt/in (mt/seconds wait) #(md/recur all-failures))))))))

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -73,9 +73,9 @@
     (let [sent-at (ct/now)
           ;; this should fail the retry
           fake-retry (fn [_f _p _stop]
-                      (let [d (md/deferred)]
-                        (md/success! d :cloudpassage-lib.core/retry-failure)
-                        d))]
+                       (let [d (md/deferred)]
+                         (md/success! d :cloudpassage-lib.core/retry-failure)
+                         d))]
       (with-redefs [cloudpassage-lib.core/retry fake-retry
                     clj-time.core/now (fn [] sent-at)]
         (is (= :cloudpassage-lib.core/auth-failure

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -60,21 +60,21 @@
       (with-redefs [aleph.http/post fake-post
                     clj-time.core/now (fn [] sent-at)]
         (is (= response @(core/get-auth-token! "secret-key" "id"))))))
-  (testing "blows up on failure to get a token"
+  (testing "throws an exception on error"
     (let [sent-at (ct/now)
           msg "oh oh no - you are not allowed"
           fake-post (fn [_addr _opts]
                       (let [d (md/deferred)]
                         (md/error!
                          d
-                         (Exception. msg))
+                         (throw (Exception. msg)))
                         d))]
       (with-redefs [aleph.http/post fake-post
                     clj-time.core/now (fn [] sent-at)]
         (is (thrown-with-msg?
              Exception
              (re-pattern msg)
-             @(core/get-auth-token! "secret-key" "id")))))))
+             (core/get-auth-token! "secret-key" "id")))))))
 
 (deftest iso-date-tests
   (testing "it actually formats dates"

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -94,10 +94,10 @@
         (mt/with-clock c
           (let [result (core/get-auth-token! "secret-key" "id")]
             (is (= 1 @attempts))
-            (mt/advance c (mt/seconds 25))
+            (mt/advance c (mt/seconds 16))
 
             (is (= 2 @attempts))
-            (mt/advance c (mt/seconds 125))
+            (mt/advance c (mt/seconds 64))
 
             (is (= 3 @attempts))
             (is (= :cloudpassage-lib.core/auth-failure @result))))))))

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -86,11 +86,11 @@
         (mt/with-clock c
           (let [result (core/get-auth-token! "secret-key" "id")]
             (is (= 1 @attempts))
+
             (mt/advance c (mt/seconds 16))
-
             (is (= 2 @attempts))
-            (mt/advance c (mt/seconds 64))
 
+            (mt/advance c (mt/seconds 64))
             (is (= 3 @attempts))
             (is (thrown-with-msg?
                  Exception

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -9,7 +9,7 @@
             [cloudpassage-lib.test-utils :refer [use-atom-log-appender!]]
             [cloudpassage-lib.core :as core]))
 
-(deftest retry!-tests
+(deftest retry-tests
   (testing "retries until stop is reached"
     (let [c (mt/mock-clock)
           attempts (atom 0)
@@ -23,7 +23,7 @@
           stop 3]
       (mt/with-clock c
         (let [log (use-atom-log-appender!)
-              ret (core/retry! p f stop)]
+              ret (core/retry p f stop)]
           (is (= 1 @attempts))
           (is (str/includes? (first @log) (str "Failure retrying: " exc)))
 
@@ -49,7 +49,7 @@
                 (md/success! d v)
                 d))]
       (mt/with-clock c
-        (let [ret (core/retry! p f stop)]
+        (let [ret (core/retry p f stop)]
           (mt/advance c 1)
           (is (= v @ret)))))))
 

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -20,22 +20,17 @@
               (let [d (md/deferred)]
                 (md/error! d (Exception. exc))
                 d))
-          log-contains? (fn [log-msg text]
-                          (str/includes? log-msg text))
           stop 3]
       (mt/with-clock c
         (let [log (use-atom-log-appender!)
               ret (core/retry f p stop)]
           (is (= 1 @attempts))
-          (is (log-contains? (first @log) exc))
 
           (mt/advance c (mt/seconds p))
           (is (= 2 @attempts))
-          (is (log-contains? (second @log) exc))
 
           (mt/advance c (mt/seconds (* p p)))
           (is (= 3 @attempts))
-          (is (log-contains? (second (rest @log)) exc))
           (is (thrown-with-msg? Exception #"explosion" @ret))))))
   (testing "returns success deferred on completion"
     (let [c (mt/mock-clock)

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -23,7 +23,7 @@
           stop 3]
       (mt/with-clock c
         (let [log (use-atom-log-appender!)
-              ret (core/retry p f stop)]
+              ret (core/retry f p stop)]
           (is (= 1 @attempts))
           (is (str/includes? (first @log) (str "Failure retrying: " exc)))
 
@@ -49,7 +49,7 @@
                 (md/success! d v)
                 d))]
       (mt/with-clock c
-        (let [ret (core/retry p f stop)]
+        (let [ret (core/retry f p stop)]
           (mt/advance c 1)
           (is (= v @ret)))))))
 

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -20,7 +20,22 @@
                         foo))]
       (with-redefs [aleph.http/post fake-post
                     clj-time.core/now (fn [] sent-at)]
-        (is (= response (core/get-auth-token! "secret-key" "id")))))))
+        (is (= response @(core/get-auth-token! "secret-key" "id"))))))
+  (testing "blows up on failure to get a token"
+    (let [sent-at (ct/now)
+          msg "oh oh no - you are not allowed"
+          fake-post (fn [_addr _opts]
+                      (let [d (md/deferred)]
+                        (md/error!
+                         d
+                         (Exception. msg))
+                        d))]
+      (with-redefs [aleph.http/post fake-post
+                    clj-time.core/now (fn [] sent-at)]
+        (is (thrown-with-msg?
+             Exception
+             (re-pattern msg)
+             @(core/get-auth-token! "secret-key" "id")))))))
 
 (deftest iso-date-tests
   (testing "it actually formats dates"

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -33,13 +33,16 @@
 
           (mt/advance c (mt/seconds (* p p)))
           (is (= 3 @attempts))
-          (is (str/includes? (second (rest @log)) (str "Failure retrying: " exc)))
+          (is (str/includes?
+               (second (rest @log))
+               (str "Failure retrying: " exc)))
+
           (is (str/includes?
                (last @log)
                "Failed retrying 3 times; stopping"))
           (is (thrown-with-msg?
                Exception
-               #"Failed retrying"
+               #"Failed retrying; stopping"
                @ret))))))
   (testing "returns success deferred on completion"
     (let [c (mt/mock-clock)
@@ -93,7 +96,7 @@
             (is (= 3 @attempts))
             (is (thrown-with-msg?
                  Exception
-                 #"Failed retry"
+                 #"Failed retrying; stopping"
                  @result))))))))
 
 (deftest iso-date-tests

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -69,21 +69,16 @@
       (with-redefs [aleph.http/post fake-post
                     clj-time.core/now (fn [] sent-at)]
         (is (= response @(core/get-auth-token! "secret-key" "id"))))))
-  (testing "throws an exception on error"
+  (testing "returns an :cloudpassage-lib.core/auth-failure on failure"
     (let [sent-at (ct/now)
-          msg "oh oh no - you are not allowed"
           fake-post (fn [_addr _opts]
                       (let [d (md/deferred)]
-                        (md/error!
-                         d
-                         (throw (Exception. msg)))
+                        (md/success! d :cloudpassage-lib.core/retry-failure)
                         d))]
       (with-redefs [aleph.http/post fake-post
                     clj-time.core/now (fn [] sent-at)]
-        (is (thrown-with-msg?
-             Exception
-             (re-pattern msg)
-             (core/get-auth-token! "secret-key" "id")))))))
+        (is (= :cloudpassage-lib.core/auth-failure
+               @(core/get-auth-token! "secret-key" "id")))))))
 
 (deftest iso-date-tests
   (testing "it actually formats dates"

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -13,7 +13,7 @@
   (testing "retries until stop is reached and returns error deferred"
     (let [c (mt/mock-clock)
           attempts (atom 0)
-          p 5
+          p 4
           exc "inner explosion"
           f (fn []
               (swap! attempts inc)
@@ -31,10 +31,9 @@
           (is (= 2 @attempts))
           (is (str/includes? (second @log) (str "Failure retrying: " exc)))
 
-          (mt/advance c (mt/seconds (math/expt p 2)))
+          (mt/advance c (mt/seconds (* p p)))
           (is (= 3 @attempts))
           (is (str/includes? (second (rest @log)) (str "Failure retrying: " exc)))
-
           (is (str/includes?
                (last @log)
                "Failed retrying 3 times; stopping"))
@@ -87,10 +86,10 @@
           (let [result (core/get-auth-token! "secret-key" "id")]
             (is (= 1 @attempts))
 
-            (mt/advance c (mt/seconds 16))
+            (mt/advance c (mt/seconds 4))
             (is (= 2 @attempts))
 
-            (mt/advance c (mt/seconds 64))
+            (mt/advance c (mt/seconds 16))
             (is (= 3 @attempts))
             (is (thrown-with-msg?
                  Exception

--- a/test/cloudpassage_lib/retry_test.clj
+++ b/test/cloudpassage_lib/retry_test.clj
@@ -1,0 +1,69 @@
+(ns cloudpassage-lib.retry-test
+  (:require [clojure.test :refer :all]
+            [manifold.deferred :as md]
+            [manifold.time :as mt]
+            [clojure.math.numeric-tower :as math]
+            [cloudpassage-lib.test-utils :refer [use-atom-log-appender!]]
+            [cloudpassage-lib.retry :as retry]))
+
+(deftest exponentially-tests
+  (testing "returns a function that will raise the wait period to the number of failures"
+    (let [f (retry/exponentially 10)]
+      (is (= 1 (f [])))
+      (is (= 10 (f [:a])))
+      (is (= 1000 (f [:a :b :c]))))))
+
+(deftest up-to-tests
+  (testing "raises when number of tries exceeded "
+    (let [tries [(Exception. "earlier")
+                 (Exception. "recent")]
+          stop 2
+          retry? #(throw (Exception. "I shouldn't have been called"))
+          f (retry/up-to stop retry?)]
+      (is (thrown-with-msg?
+           Exception
+           #"recent"
+           (f tries)))))
+  (testing "returns the result of retry when number of tries less than max"
+    (let [tries []
+          retry? (constantly :success)
+          stop 2
+          f (retry/up-to stop retry?)]
+      (is (= :success (f tries))))))
+
+(deftest retry-exp-backoff-tests
+  (testing "retries until stop is reached and re-throws last exception"
+    (let [c (mt/mock-clock)
+          attempts (atom 0)
+          p 4
+          exc "explosion"
+          f (fn []
+              (swap! attempts inc)
+              (let [d (md/deferred)]
+                (md/error! d (Exception. exc))
+                d))
+          stop 3]
+      (mt/with-clock c
+        (let [log (use-atom-log-appender!)
+              ret (retry/retry-exp-backoff f p stop)]
+          (is (= 1 @attempts))
+
+          (mt/advance c (mt/seconds p))
+          (is (= 2 @attempts))
+
+          (mt/advance c (mt/seconds (* p p)))
+          (is (= 3 @attempts))
+          (is (thrown-with-msg? Exception #"explosion" @ret))))))
+  (testing "returns success deferred on completion"
+    (let [c (mt/mock-clock)
+          v "hi"
+          stop 1
+          p 5
+          f (fn []
+              (let [d (md/deferred)]
+                (md/success! d v)
+                d))]
+      (mt/with-clock c
+        (let [ret (retry/retry-exp-backoff f p stop)]
+          (mt/advance c 1)
+          (is (= v @ret)))))))

--- a/test/cloudpassage_lib/retry_test.clj
+++ b/test/cloudpassage_lib/retry_test.clj
@@ -14,7 +14,7 @@
       (is (= 1000 (f [:a :b :c]))))))
 
 (deftest up-to-tests
-  (testing "raises when number of tries exceeded "
+  (testing "raises most recent exception when number of tries exceeded"
     (let [tries [(Exception. "earlier")
                  (Exception. "recent")]
           stop 2


### PR DESCRIPTION
1. Adds exponential backoff/retry logic for deferred generating functions.
2. Changes `get-auth-token!` to return a deferred, instead of dereferencing the deferred and returning the token.
3. Wraps the `http/post` inside of `get-auth-token!` with the retry logic from (1)