### PR TITLE
Return deferred from `get-auth-token!`

### DIFF
--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -20,7 +20,22 @@
                         foo))]
       (with-redefs [aleph.http/post fake-post
                     clj-time.core/now (fn [] sent-at)]
-        (is (= response (core/get-auth-token! "secret-key" "id")))))))
+        (is (= response @(core/get-auth-token! "secret-key" "id"))))))
+  (testing "blows up on failure to get a token"
+    (let [sent-at (ct/now)
+          msg "oh oh no - you are not allowed"
+          fake-post (fn [_addr _opts]
+                      (let [d (md/deferred)]
+                        (md/error!
+                         d
+                         (Exception. msg))
+                        d))]
+      (with-redefs [aleph.http/post fake-post
+                    clj-time.core/now (fn [] sent-at)]
+        (is (thrown-with-msg?
+             Exception
+             (re-pattern msg)
+             @(core/get-auth-token! "secret-key" "id")))))))
 
 (deftest iso-date-tests
   (testing "it actually formats dates"


### PR DESCRIPTION
Modify `get-auth-token!` to return a deferred wrapping a token, instead of the actual token.

This is a PR broken out of #48.