### PR TITLE
Code and cruft cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - REDIS_URL="redis://localhost:6379" REDIS_TIMEOUT="4000"
 script:
 - lein cljfmt check
+- lein eastwood
 - lein test
 after_success:
 - CLOVERAGE_VERSION=1.0.7-SNAPSHOT lein cloverage --codecov

--- a/project.clj
+++ b/project.clj
@@ -19,6 +19,7 @@
                  [com.cemerick/url "0.1.1"]]
   :plugins [[lein-auto "0.1.2"]
             [lein-cljfmt "0.3.0"]
+            [jonase/eastwood "0.2.3"]
             [lein-pprint "1.1.1"]
             [lein-environ "1.0.2"]
             [lein-cloverage "1.0.7-SNAPSHOT"]]

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -4,7 +4,6 @@
    [aleph.http :as http]
    [environ.core :refer [env]]
    [manifold.deferred :as md]
-   [manifold.time :as mt]
    [byte-streams :as bs]
    [taoensso.carmine :as car :refer (wcar)]
    [taoensso.timbre :as timbre :refer [info warn]]

--- a/src/cloudpassage_lib/scans.clj
+++ b/src/cloudpassage_lib/scans.clj
@@ -3,20 +3,15 @@
   (:require
    [cemerick.url :as u]
    [clojure.string :as str]
-   [manifold.stream :as ms]
    [aleph.http :as http]
    [manifold.deferred :as md]
    [manifold.stream :as ms]
    [manifold.time :as mt]
    [environ.core :refer [env]]
-   [cloudpassage-lib.core :as cpc]
    [taoensso.timbre :as timbre :refer [warn error info]]
-   [clj-time.core :as t :refer [hours ago]]
-   [clj-time.format :as tf]
    [camel-snake-kebab.core :as cskc]
    [camel-snake-kebab.extras :as cske]
-   [clojure.java.io :as io]
-   [clojure.string :refer [blank?]]))
+   [cloudpassage-lib.core :as cpc]))
 
 (def ^:private base-scans-url
   "https://api.cloudpassage.com/v1/scans/")
@@ -82,7 +77,7 @@
           (let [resource (resource-key response)
                 pagination (:pagination response)
                 next-url (:next pagination)]
-            (if (blank? next-url)
+            (if (str/blank? next-url)
               (do (info "no more urls to fetch")
                   (ms/close! urls-stream))
               (ms/put! urls-stream next-url))

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -4,7 +4,6 @@
             [manifold.time :as mt]
             [clj-time.core :as ct]
             [cheshire.core :as json]
-            [clojure.string :as str]
             [cloudpassage-lib.core :as core]))
 
 (deftest get-auth-token!-tests

--- a/test/cloudpassage_lib/core_test.clj
+++ b/test/cloudpassage_lib/core_test.clj
@@ -42,7 +42,7 @@
   (testing "it actually formats dates"
     (let [a-date (ct/date-time 1986 10 14 4 3 27 456)
           formatted (core/->cp-date a-date)]
-      (is (= formatted "1986-10-14T04:03:27Z")))))
+      (is (= "1986-10-14T04:03:27Z" formatted)))))
 
 (deftest get-single-events-page!-tests
   (testing "returns ::fetch-error on exception"

--- a/test/cloudpassage_lib/redis_test.clj
+++ b/test/cloudpassage_lib/redis_test.clj
@@ -12,10 +12,7 @@
 
 (deftest fetch-token!-tests
   (let [fernet-key (fernet/generate-key)
-        succeed-get-fake-token (fn [t]
-                                 (let [d (md/deferred)]
-                                   (md/success! d t)
-                                   d))]
+        succeed-get-fake-token (fn [t] (md/success-deferred t))]
     (testing "encrypts new api token with fernet"
       (let [client-id "client-id"
             token-key (str "account-" client-id)

--- a/test/cloudpassage_lib/redis_test.clj
+++ b/test/cloudpassage_lib/redis_test.clj
@@ -1,7 +1,5 @@
 (ns cloudpassage-lib.redis-test
   (:require [clojure.test :refer :all]
-            [clj-time.core :as ct]
-            [clj-time.coerce :as c]
             [taoensso.carmine :as car]
             [fernet.core :as fernet]
             [cloudpassage-lib.core :as core]

--- a/test/cloudpassage_lib/retry_test.clj
+++ b/test/cloudpassage_lib/retry_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer :all]
             [manifold.deferred :as md]
             [manifold.time :as mt]
-            [clojure.math.numeric-tower :as math]
             [cloudpassage-lib.test-utils :refer [use-atom-log-appender!]]
             [cloudpassage-lib.retry :as retry]))
 

--- a/test/cloudpassage_lib/scans_test.clj
+++ b/test/cloudpassage_lib/scans_test.clj
@@ -40,9 +40,7 @@
 (deftest get-page-retry!-tests
   (testing "Throws an exception after three retries"
     (let [fake-get (fn [token uri]
-                     (let [d (md/deferred)]
-                       (md/success! d :cloudpassage-lib.core/fetch-error)
-                       d))]
+                     (md/success-deferred :cloudpassage-lib.core/fetch-error))]
       (with-redefs [cpc/get-single-events-page! fake-get]
         (let [c (mt/mock-clock 0)
               timeout 3000
@@ -61,9 +59,7 @@
   (testing "Doesn't retry on good response"
     (let [scan {:scan-id 1 :module "fim"}
           fake-get (fn [token uri]
-                     (let [d (md/deferred)]
-                       (md/success! d scan)
-                       d))]
+                     (md/success-deferred scan))]
       (with-redefs [cpc/get-single-events-page! fake-get]
         (let [log (use-atom-log-appender!)
               ;; Returns instantly since no retries are necessary

--- a/test/cloudpassage_lib/scans_test.clj
+++ b/test/cloudpassage_lib/scans_test.clj
@@ -109,8 +109,8 @@
 
    The only valid credentials are the account:secret pair 'lvh:hunter2'."
   [client-id client-secret url]
-  (is (= client-id "lvh"))
-  (is (= client-secret "hunter2"))
+  (is (= "lvh" client-id))
+  (is (= "hunter2" client-secret))
   (let [parsed-url (u/url url)
         query (:query parsed-url)
         page-num (-> query
@@ -163,8 +163,8 @@
 
 (defn ^:private parse-fake-request
   [client-id client-secret url]
-  (is (= client-id "lvh"))
-  (is (= client-secret "hunter2"))
+  (is (= "lvh" client-id))
+  (is (= "hunter2" client-secret))
   (let [parsed-url (u/url url)
         path (:path parsed-url)
         query (:query parsed-url)

--- a/test/cloudpassage_lib/scans_test.clj
+++ b/test/cloudpassage_lib/scans_test.clj
@@ -4,14 +4,13 @@
    [cloudpassage-lib.core :as cpc :refer [cp-date-formatter]]
    [cloudpassage-lib.test-utils :refer [use-atom-log-appender!]]
    [clj-time.format :as tf]
-   [clj-time.core :as t :refer [millis hours ago within?]]
+   [clj-time.core :as t :refer [hours ago within?]]
    [clojure.string :as str]
    [clojure.test :refer [deftest testing is are]]
    [manifold.deferred :as md]
    [manifold.stream :as ms]
    [manifold.time :as mt]
-   [cemerick.url :as u]
-   [taoensso.timbre :as timbre :refer [info spy]]))
+   [cemerick.url :as u]))
 
 (deftest scans-url-tests
   (are [opts expected] (= expected (#'scans/scans-url opts))


### PR DESCRIPTION
We had a lot of unused imports which I removed here. I also cleaned up some tests with manifold's `success-deferred` and added linting (fixing the 'Yoda' tests it was complaining about).