### PR TITLE
Remove 'error' from warning, avoiding false alerts

### DIFF
--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -82,7 +82,7 @@
      (md/catch
       Exception
       (fn [exc]
-        (warn "error fetching events page:" (.getMessage exc))
+        (warn "problem fetching events page:" (.getMessage exc))
         ::fetch-error)))))
 
 (defn page-response-ok?


### PR DESCRIPTION
This is just a quick fix to help with alerting/monitoring. Currently warnings are generating alerts because they contain the text "error", so this fixes that.