### PR TITLE
Die if redis environment variables aren't defined

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [cheshire "5.5.0"]
                  [camel-snake-kebab "0.3.2"]
                  [org.clojure/math.numeric-tower "0.0.4"]
+                 [com.gfredericks/system-slash-exit "0.2.0"]
                  [com.cemerick/url "0.1.1"]]
   :plugins [[lein-auto "0.1.2"]
             [lein-cljfmt "0.3.0"]

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -6,7 +6,8 @@
    [manifold.deferred :as md]
    [byte-streams :as bs]
    [taoensso.carmine :as car :refer (wcar)]
-   [taoensso.timbre :as timbre :refer [info warn]]
+   [taoensso.timbre :as timbre :refer [info warn fatal]]
+   [com.gfredericks.system-slash-exit :refer [exit]]
    [base64-clj.core :as base64]
    [clj-time.core :as time]
    [clj-time.format :as f]
@@ -21,6 +22,9 @@
 (defn redis-connection
   []
   (let [{:keys [redis-url redis-timeout]} env]
+    (when-not (and redis-url redis-timeout)
+      (fatal "REDIS_URL and REDIS_TIMEOUT environment vars must be defined")
+      (exit 1))
     {:pool {}
      :spec {:uri redis-url
             :timeout (read-string redis-timeout)}}))


### PR DESCRIPTION
Partially addresses #12.

After seeing @derwolfe get confused by this on yet another PR, I decided it was time to fix this. When REDIS_URL and REDIS_TIMEOUT environment variables aren't set, cloudpassage-lib will log a fatal error and exit, as it cannot operate without these defined.