### PR TITLE
Quiet down the logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+- Make logging less noisy by moving cache into to TRACE level
+
 # 1.0.0
 
 ## Breaking changes

--- a/src/cloudpassage_lib/core.clj
+++ b/src/cloudpassage_lib/core.clj
@@ -103,11 +103,11 @@
     (if (cache/has? current-cache account-key)
       ;; if there is a token, then return it
       (let [updated-cache (swap! cache-state cache/hit account-key)]
-        (timbre/info "Cache hit" account-key)
+        (timbre/trace "Cache hit" account-key)
         (cache/lookup updated-cache account-key))
       ;; otherwise, go fetch a new one, cache it (with the default for the cache)
       ;; and return the _new_ token
       (let [{:keys [access_token]} @(get-auth-token! client-id client-secret)]
-        (timbre/info "Cache miss" account-key)
+        (timbre/trace "Cache miss" account-key)
         (swap! cache-state cache/miss account-key access_token)
         access_token))))


### PR DESCRIPTION
Just tested the new version of cloudpassage-lib with clark-kent, and every single time the cache is checked a log message is printed. This makes the logs a little noisier than I'd like.

I've moved these messages to TRACE level, which aren't printed by default.